### PR TITLE
[Bridge] relayer indexes are not stable

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -103,10 +103,6 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         require(hasRole(RELAYER_ROLE, _msgSender()), "sender doesn't have relayer role");
     }
 
-    function _relayerBit(address relayer) private view returns(uint) {
-        return uint(1) << sub(AccessControl.getRoleMemberIndex(RELAYER_ROLE, relayer), 1);
-    }
-
     function _hasVoted(uint72 nonceAndID, bytes32 dataHash, address relayer) private view returns(bool) {
         Proposal memory proposal = _proposals[nonceAndID][dataHash];
         bool voted = _proposalVotes[nonceAndID][dataHash][relayer];

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -29,7 +29,6 @@ contract Bridge is Pausable, AccessControl, SafeMath {
 
     struct Proposal {
         ProposalStatus _status;
-        uint200 _yesVotes;      // bitmap, 200 maximum votes
         uint8   _yesVotesTotal;
         uint40  _proposedBlock; // 1099511627775 maximum block
     }
@@ -42,6 +41,9 @@ contract Bridge is Pausable, AccessControl, SafeMath {
     mapping(address => bool) public isValidForwarder;
     // destinationDomainID + depositNonce => dataHash => Proposal
     mapping(uint72 => mapping(bytes32 => Proposal)) private _proposals;
+
+    // destinationDomainID + depositNonce => dataHash => relayerAddress => isVoted
+    mapping(uint72 => mapping(bytes32 => mapping(address => bool))) private _proposalVotes;
 
     event RelayerThresholdChanged(uint256 newThreshold);
     event RelayerAdded(address relayer);
@@ -105,8 +107,10 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         return uint(1) << sub(AccessControl.getRoleMemberIndex(RELAYER_ROLE, relayer), 1);
     }
 
-    function _hasVoted(Proposal memory proposal, address relayer) private view returns(bool) {
-        return (_relayerBit(relayer) & uint(proposal._yesVotes)) > 0;
+    function _hasVoted(uint72 nonceAndID, bytes32 dataHash, address relayer) private view returns(bool) {
+        Proposal memory proposal = _proposals[nonceAndID][dataHash];
+        bool voted = _proposalVotes[nonceAndID][dataHash][relayer];
+        return voted && proposal._proposedBlock > 0;
     }
 
     function _msgSender() internal override view returns (address) {
@@ -147,7 +151,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @param relayer Address to check.
      */
     function _hasVotedOnProposal(uint72 destNonce, bytes32 dataHash, address relayer) public view returns(bool) {
-        return _hasVoted(_proposals[destNonce][dataHash], relayer);
+        return _hasVoted(destNonce, dataHash, relayer);
     }
 
     /**
@@ -298,7 +302,6 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         @param dataHash Hash of data to be provided when deposit proposal is executed.
         @return Proposal which consists of:
         - _dataHash Hash of data to be provided when deposit proposal is executed.
-        - _yesVotes Number of votes in favor of proposal.
         - _noVotes Number of votes against proposal.
         - _status Current status of proposal.
      */
@@ -391,12 +394,11 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         address sender = _msgSender();
         
         require(uint(proposal._status) <= 1, "proposal already executed/cancelled");
-        require(!_hasVoted(proposal, sender), "relayer already voted");
+        require(!_hasVoted(nonceAndID, dataHash, sender), "relayer already voted");
 
         if (proposal._status == ProposalStatus.Inactive) {
             proposal = Proposal({
                 _status : ProposalStatus.Active,
-                _yesVotes : 0,
                 _yesVotesTotal : 0,
                 _proposedBlock : uint40(block.number) // Overflow is desired.
             });
@@ -411,7 +413,7 @@ contract Bridge is Pausable, AccessControl, SafeMath {
         }
 
         if (proposal._status != ProposalStatus.Cancelled) {
-            proposal._yesVotes = (proposal._yesVotes | _relayerBit(sender)).toUint200();
+            _proposalVotes[nonceAndID][dataHash][sender] = true;
             proposal._yesVotesTotal++; // TODO: check if bit counting is cheaper.
 
             emit ProposalVote(domainID, depositNonce, proposal._status, dataHash);

--- a/contracts/ERC721Safe.sol
+++ b/contracts/ERC721Safe.sol
@@ -55,8 +55,9 @@ contract ERC721Safe {
         @param tokenAddress Address of ERC721 to burn.
         @param tokenID ID of token to burn.
      */
-    function burnERC721(address tokenAddress, uint256 tokenID) internal {
+    function burnERC721(address tokenAddress, address owner, uint256 tokenID) internal {
         ERC721MinterBurnerPauser erc721 = ERC721MinterBurnerPauser(tokenAddress);
+        require(erc721.ownerOf(tokenID) == owner, 'Burn not from owner');
         erc721.burn(tokenID);
     }
 

--- a/contracts/handlers/ERC721Handler.sol
+++ b/contracts/handlers/ERC721Handler.sol
@@ -58,7 +58,7 @@ contract ERC721Handler is IDepositExecute, HandlerHelpers, ERC721Safe {
         }
 
         if (_burnList[tokenAddress]) {
-            burnERC721(tokenAddress, tokenID);
+            burnERC721(tokenAddress, depositer, tokenID);
         } else {
             lockERC721(tokenAddress, depositer, address(this), tokenID);
         }

--- a/test/contractBridge/cancelDepositProposal.js
+++ b/test/contractBridge/cancelDepositProposal.js
@@ -19,9 +19,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
     const relayer2Address = accounts[1];
     const relayer3Address = accounts[2];
     const relayer4Address = accounts[3];
-    const relayer1Bit = 1 << 0;
-    const relayer2Bit = 1 << 1;
-    const relayer3Bit = 1 << 2;
     const destinationChainRecipientAddress = accounts[4];
     const depositAmount = 10;
     const expectedDepositNonce = 1;
@@ -81,7 +78,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         await TruffleAssert.passes(vote(relayer1Address));
 
         const expectedDepositProposal = {
-            _yesVotes: relayer1Bit.toString(),
             _yesVotesTotal: '1',
             _status: '1' // Active
         };
@@ -105,7 +101,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         await TruffleAssert.passes(vote(relayer2Address));
         
         const expectedDepositProposal = {
-            _yesVotes: relayer1Bit.toString(),
             _yesVotesTotal: '1',
             _status: '4' // Cancelled
         };
@@ -124,7 +119,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         }
 
         const expectedDepositProposal = {
-            _yesVotes: relayer2Bit.toString(),
             _yesVotesTotal: '1',
             _status: '4' // Cancelled
         };
@@ -149,7 +143,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         }
 
         const expectedDepositProposal = {
-            _yesVotes: relayer3Bit.toString(),
             _yesVotesTotal: '1',
             _status: '4' // Cancelled
         };

--- a/test/contractBridge/createDepositProposal.js
+++ b/test/contractBridge/createDepositProposal.js
@@ -95,7 +95,6 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
 
     it('depositProposal should be created with expected values', async () => {
         const expectedDepositProposal = {
-            _yesVotes: originChainRelayerBit.toString(),
             _yesVotesTotal: '1',
             _status: '2' // passed
         };
@@ -224,7 +223,6 @@ contract('Bridge - [create a deposit proposal (voteProposal) with relayerThresho
 
     it('depositProposal should be created with expected values', async () => {
         const expectedDepositProposal = {
-            _yesVotes: originChainRelayerBit.toString(),
             _yesVotesTotal: '1',
             _status: '1' // active
         };

--- a/test/contractBridge/voteDepositProposal.js
+++ b/test/contractBridge/voteDepositProposal.js
@@ -19,9 +19,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
     const relayer2Address = accounts[1];
     const relayer3Address = accounts[2];
     const relayer4Address = accounts[3];
-    const relayer1Bit = 1 << 0;
-    const relayer2Bit = 1 << 1;
-    const relayer3Bit = 1 << 2;
     const depositerAddress = accounts[4];
     const destinationChainRecipientAddress = accounts[4];
     const depositAmount = 10;
@@ -97,7 +94,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         await TruffleAssert.passes(vote(relayer1Address));
 
         const expectedDepositProposal = {
-            _yesVotes: relayer1Bit.toString(),
             _yesVotesTotal: '1',
             _status: '1' // Active
         };
@@ -157,7 +153,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         const depositProposalAfterFirstVote = await BridgeInstance.getProposal(
             originDomainID, expectedDepositNonce, depositDataHash);
         assert.equal(depositProposalAfterFirstVote._yesVotesTotal, 1);
-        assert.equal(depositProposalAfterFirstVote._yesVotes, relayer1Bit);
         assert.strictEqual(depositProposalAfterFirstVote._status, STATUS.Active);
 
         await TruffleAssert.passes(vote(relayer2Address));
@@ -165,7 +160,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         const depositProposalAfterSecondVote = await BridgeInstance.getProposal(
             originDomainID, expectedDepositNonce, depositDataHash);
         assert.equal(depositProposalAfterSecondVote._yesVotesTotal, 2);
-        assert.equal(depositProposalAfterSecondVote._yesVotes, relayer1Bit + relayer2Bit);
         assert.strictEqual(depositProposalAfterSecondVote._status, STATUS.Active);
 
         await TruffleAssert.passes(vote(relayer3Address)); // After this vote, automatically executes the proposal.
@@ -173,7 +167,6 @@ contract('Bridge - [voteProposal with relayerThreshold == 3]', async (accounts) 
         const depositProposalAfterThirdVote = await BridgeInstance.getProposal(
             originDomainID, expectedDepositNonce, depositDataHash);
         assert.equal(depositProposalAfterThirdVote._yesVotesTotal, 3);
-        assert.equal(depositProposalAfterThirdVote._yesVotes, relayer1Bit + relayer2Bit + relayer3Bit);
         assert.strictEqual(depositProposalAfterThirdVote._status, STATUS.Executed); // Executed
     });
 

--- a/test/contractBridge/voteDepositProposalWithRealForwarder.js
+++ b/test/contractBridge/voteDepositProposalWithRealForwarder.js
@@ -26,9 +26,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
     const relayer2Address = relayer2.getAddressString();
     const relayer3Address = relayer3.getAddressString();
     const relayer4Address = relayer4.getAddressString();
-    const relayer1Bit = 1 << 0;
-    const relayer2Bit = 1 << 1;
-    const relayer3Bit = 1 << 2;
     const depositer = Wallet.generate();
     const depositerAddress = depositer.getAddressString();
     const destinationChainRecipientAddress = accounts[4];
@@ -166,7 +163,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
 
         await ForwarderInstance.execute(request, sign);
         const expectedDepositProposal = {
-            _yesVotes: relayer1Bit.toString(),
             _yesVotesTotal: '1',
             _status: '1' // Active
         };
@@ -271,7 +267,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
         await ForwarderInstance.execute(request, sign);
 
         const expectedDepositProposal = {
-            _yesVotes: '0',
             _yesVotesTotal: '0',
             _status: '0'
         };

--- a/test/contractBridge/voteDepositProposalWithTestForwarder.js
+++ b/test/contractBridge/voteDepositProposalWithTestForwarder.js
@@ -20,9 +20,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
     const relayer2Address = accounts[1];
     const relayer3Address = accounts[2];
     const relayer4Address = accounts[3];
-    const relayer1Bit = 1 << 0;
-    const relayer2Bit = 1 << 1;
-    const relayer3Bit = 1 << 2;
     const depositerAddress = accounts[4];
     const destinationChainRecipientAddress = accounts[4];
     const depositAmount = 10;
@@ -99,7 +96,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
     it('[sanity] depositProposal should be created with expected values after the vote through forwarder', async () => {
         await ForwarderInstance.execute(voteCallData, BridgeInstance.address, relayer1Address);
         const expectedDepositProposal = {
-            _yesVotes: relayer1Bit.toString(),
             _yesVotesTotal: '1',
             _status: '1' // Active
         };
@@ -153,7 +149,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
         const depositProposalAfterFirstVote = await BridgeInstance.getProposal(
             originDomainID, expectedDepositNonce, depositDataHash);
         assert.equal(depositProposalAfterFirstVote._yesVotesTotal, 1);
-        assert.equal(depositProposalAfterFirstVote._yesVotes, relayer1Bit);
         assert.strictEqual(depositProposalAfterFirstVote._status, STATUS.Active);
 
         await ForwarderInstance.execute(voteCallData, BridgeInstance.address, relayer2Address);
@@ -161,7 +156,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
         const depositProposalAfterSecondVote = await BridgeInstance.getProposal(
             originDomainID, expectedDepositNonce, depositDataHash);
         assert.equal(depositProposalAfterSecondVote._yesVotesTotal, 2);
-        assert.equal(depositProposalAfterSecondVote._yesVotes, relayer1Bit + relayer2Bit);
         assert.strictEqual(depositProposalAfterSecondVote._status, STATUS.Active);
 
         await ForwarderInstance.execute(voteCallData, BridgeInstance.address, relayer3Address); // After this vote, automatically executes the proposal.
@@ -169,7 +163,6 @@ contract('Bridge - [voteProposal through forwarder]', async (accounts) => {
         const depositProposalAfterThirdVote = await BridgeInstance.getProposal(
             originDomainID, expectedDepositNonce, depositDataHash);
         assert.equal(depositProposalAfterThirdVote._yesVotesTotal, 3);
-        assert.equal(depositProposalAfterThirdVote._yesVotes, relayer1Bit + relayer2Bit + relayer3Bit);
         assert.strictEqual(depositProposalAfterThirdVote._status, STATUS.Executed); // Executed
     });
 

--- a/test/handlers/erc721/depositBurn.js
+++ b/test/handlers/erc721/depositBurn.js
@@ -89,4 +89,14 @@ contract('ERC721Handler - [Deposit Burn ERC721]', async (accounts) => {
             ERC721MintableInstance1.ownerOf(tokenID),
             'ERC721: owner query for nonexistent token');
     });
+    it('depositAmount of ERC721MintableInstance1 tokens should NOT burn from NOT token owner', async () => {
+        await TruffleAssert.reverts(BridgeInstance.deposit(
+                destinationDomainID,
+                resourceID1,
+                depositData,
+                feeData,
+                { from: accounts[3] }
+            ),
+            'Burn not from owner');
+    });
 });

--- a/test/handlers/erc721/depositBurn.js
+++ b/test/handlers/erc721/depositBurn.js
@@ -91,10 +91,9 @@ contract('ERC721Handler - [Deposit Burn ERC721]', async (accounts) => {
     });
     it('depositAmount of ERC721MintableInstance1 tokens should NOT burn from NOT token owner', async () => {
         await TruffleAssert.reverts(BridgeInstance.deposit(
-                destinationDomainID,
+                domainID,
                 resourceID1,
                 depositData,
-                feeData,
                 { from: accounts[3] }
             ),
             'Burn not from owner');


### PR DESCRIPTION
Relayer indexes are not stable after mutation in Bridge contract

## Description

Base on Audit:
- AccessControl's _roles are EnumerableSet.AddressSet, which implements remove action by swapping with last member and pop. Index of the last element will be invalidated after that, so _relayerBit(...) will be invalid for that specified bit.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] Update new way of storing votes
- [x] Pass all test cases